### PR TITLE
Make regex() validator accept pattern and options, not a regex object

### DIFF
--- a/NGRValidator/NGRValidator/Extensions/NGRPropertyValidator+Syntax.h
+++ b/NGRValidator/NGRValidator/Extensions/NGRPropertyValidator+Syntax.h
@@ -25,9 +25,14 @@ typedef NS_ENUM(NSInteger, NGRSyntax) {
 
 
 /**
- *  Validates that the NSString match given regex.
+ *  Validates that the NSString matches given regex.
  */
 @property (copy, nonatomic, readonly) NGRPropertyValidator *(^regex)(NSRegularExpression *);
+
+/**
+ *  Validates that the NSString matches the given regex pattern string.
+ */
+@property (copy, nonatomic, readonly) NGRPropertyValidator *(^regexPattern)(NSString *);
 
 #pragma mark - Messaging
 

--- a/NGRValidator/NGRValidator/Extensions/NGRPropertyValidator+Syntax.h
+++ b/NGRValidator/NGRValidator/Extensions/NGRPropertyValidator+Syntax.h
@@ -25,14 +25,9 @@ typedef NS_ENUM(NSInteger, NGRSyntax) {
 
 
 /**
- *  Validates that the NSString matches given regex.
+ *  Validates that the NSString matches given regex pattern with options.
  */
-@property (copy, nonatomic, readonly) NGRPropertyValidator *(^regex)(NSRegularExpression *);
-
-/**
- *  Validates that the NSString matches the given regex pattern string.
- */
-@property (copy, nonatomic, readonly) NGRPropertyValidator *(^regexPattern)(NSString *);
+@property (copy, nonatomic, readonly) NGRPropertyValidator *(^regex)(NSString *, NSRegularExpressionOptions);
 
 #pragma mark - Messaging
 

--- a/NGRValidator/NGRValidator/Extensions/NGRPropertyValidator+Syntax.m
+++ b/NGRValidator/NGRValidator/Extensions/NGRPropertyValidator+Syntax.m
@@ -58,6 +58,19 @@ typedef NGRError (^NGRSyntaxValidationBlock)(NSString *string);
     };
 }
 
+- (NGRPropertyValidator *(^)(NSString *))regexPattern {
+    return ^(NSString *pattern) {
+        [self validateSyntaxWithName:@"regex" block:^NGRError(NSString *string) {
+            NSError *regexError = nil;
+            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&regexError];
+            if (regexError != nil) return NGRErrorWrongRegex;
+            NSUInteger matches = [regex numberOfMatchesInString:string options:0 range:NSMakeRange(0, string.length)];
+            return (matches == 1) ? NGRErrorNoone : NGRErrorWrongRegex;
+        }];
+        return self;
+    };
+}
+
 #pragma mark - Messaging
 
 - (NGRPropertyValidator *(^)(NSString *))msgWrongRegex {

--- a/NGRValidator/NGRValidator/Extensions/NGRPropertyValidator+Syntax.m
+++ b/NGRValidator/NGRValidator/Extensions/NGRPropertyValidator+Syntax.m
@@ -48,22 +48,10 @@ typedef NGRError (^NGRSyntaxValidationBlock)(NSString *string);
     };
 }
 
-- (NGRPropertyValidator *(^)(NSRegularExpression *))regex {
-    return ^(NSRegularExpression *aRegex) {
+- (NGRPropertyValidator *(^)(NSString *, NSRegularExpressionOptions))regex {
+    return ^(NSString *pattern, NSRegularExpressionOptions options) {
         [self validateSyntaxWithName:@"regex" block:^NGRError(NSString *string) {
-            NSUInteger matches = [aRegex numberOfMatchesInString:string options:0 range:NSMakeRange(0, string.length)];
-            return (matches == 1) ? NGRErrorNoone : NGRErrorWrongRegex;
-        }];
-        return self;
-    };
-}
-
-- (NGRPropertyValidator *(^)(NSString *))regexPattern {
-    return ^(NSString *pattern) {
-        [self validateSyntaxWithName:@"regex" block:^NGRError(NSString *string) {
-            NSError *regexError = nil;
-            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&regexError];
-            if (regexError != nil) return NGRErrorWrongRegex;
+            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:options error:nil];
             NSUInteger matches = [regex numberOfMatchesInString:string options:0 range:NSMakeRange(0, string.length)];
             return (matches == 1) ? NGRErrorNoone : NGRErrorWrongRegex;
         }];

--- a/NGRValidatorTests/NGRValidatorSpec.m
+++ b/NGRValidatorTests/NGRValidatorSpec.m
@@ -369,6 +369,14 @@ describe(@"NGRValidator", ^{
         NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:NULL];
         validator.required().regex(regex).msgWrongRegex(kErrorMessage);
     });
+
+    test(@"regex pattern", ^() {
+        return @[rule(@"wrong regex syntax", @"baz", 1, [NSString class], nil, nil),
+                 rule(@"valid regex syntax", @"qux", 0, [NSString class], nil, nil)];
+    }, ^(NGRPropertyValidator *validator) {
+        NSString *pattern = @"q.*";
+        validator.required().regexPattern(pattern).msgWrongRegex(kErrorMessage);
+    });
     
     test(@"syntax URL", ^() {
         return @[rule(@"wrong url syntax", @"http://bar", 1, [NSString class], nil, nil),

--- a/NGRValidatorTests/NGRValidatorSpec.m
+++ b/NGRValidatorTests/NGRValidatorSpec.m
@@ -362,20 +362,10 @@ describe(@"NGRValidator", ^{
     });
     
     test(@"regex", ^() {
-        return @[rule(@"wrong regex syntax", @"foo", 1, [NSString class], nil, nil),
-                 rule(@"valid regex syntax", @"bar", 0, [NSString class], nil, nil)];
+        return @[rule(@"wrong regex syntax", @"b4z", 1, [NSString class], nil, nil),
+                 rule(@"valid regex syntax", @"QUX", 0, [NSString class], nil, nil)];
     }, ^(NGRPropertyValidator *validator) {
-        NSString *pattern = @"b[a-z]";
-        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:NULL];
-        validator.required().regex(regex).msgWrongRegex(kErrorMessage);
-    });
-
-    test(@"regex pattern", ^() {
-        return @[rule(@"wrong regex syntax", @"baz", 1, [NSString class], nil, nil),
-                 rule(@"valid regex syntax", @"qux", 0, [NSString class], nil, nil)];
-    }, ^(NGRPropertyValidator *validator) {
-        NSString *pattern = @"q.*";
-        validator.required().regexPattern(pattern).msgWrongRegex(kErrorMessage);
+        validator.required().regex(@"q.*", NSRegularExpressionCaseInsensitive).msgWrongRegex(kErrorMessage);
     });
     
     test(@"syntax URL", ^() {


### PR DESCRIPTION
This pull requests changes the `regex()` syntax validator, so that it accepts a `pattern` and `options`.

``` objc
// before
NGRValidate(@"foo").regex([NSRegularExpression regularExpressionWithPattern:@"bar" options:NSRegularExpressionCaseInsensitive error:nil]);

// after
NGRValidate(@"foo").regex(@"bar", NSRegularExpressionCaseInsensitive);
```

Rationale: Users have no gain from initializing the `NSRegularExpression` themselves, the only thing they care about is pattern and options.
