### PR TITLE
Include nice header_dir in podspec

### DIFF
--- a/ngrvalidator.podspec
+++ b/ngrvalidator.podspec
@@ -1,3 +1,4 @@
+#
 #  NGRValidator
 #
 #  Created by Patryk Kaczmarek on 29.12.2014.
@@ -19,7 +20,9 @@ Pod::Spec.new do |s|
   s.source        = { :git => 'https://github.com/netguru/ngrvalidator.git', :tag => s.version.to_s }
 
   s.platform      = :ios, '7.0'
-  s.source_files  = 'NGRValidator/NGRValidator/**/*.{h,m}'
   s.requires_arc  = true
+
+  s.source_files  = 'NGRValidator/NGRValidator/**/*.{h,m}'
+  s.header_dir    = 'NGRValidator'
 
 end


### PR DESCRIPTION
This pull request adds a `header_dir` setting to the podspec, so that the import statement is:

``` objc
// cocoapods 0.35
#import <NGRValidator/NGRValidator.h>

// cocoapods 0.36
@import NGRValidator;
```

instead of:

``` objc
// cocoapods 0.35
#import <ngrvalidator/NGRValidator.h>

// cocoapods 0.36
@import ngrvalidator;
```

The change **does not** affect the pod's **name**, which is still `ngrvalidator`.
