### PR TITLE
Reveal validator error domain

### DIFF
--- a/NGRValidator/NGRValidator/Categories/NSError+NGRValidator.h
+++ b/NGRValidator/NGRValidator/Categories/NSError+NGRValidator.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString * const NGRValidatorDomain;
+
 @interface NSError (NGRValidator)
 
 + (instancetype)ngr_errorWithDescription:(NSString *)description;


### PR DESCRIPTION
Sometimes it's useful to check `NSError`'s error domain to make error handling more specific for each error type. This PR helps to achieve that by revealing `NGRValidatorDomain` as `extern`, so no additional string declaration is needed outside validator.
