### PR TITLE
Maintenance bump & additional error user info key

### DIFF
--- a/NGRValidator.xcodeproj/project.pbxproj
+++ b/NGRValidator.xcodeproj/project.pbxproj
@@ -550,6 +550,7 @@
 				5E5C0A051A498164002D3E72 /* Frameworks */,
 				5E5C0A061A498164002D3E72 /* Resources */,
 				7010E1BDA69E61E05205767B /* Copy Pods Resources */,
+				079AFF1B1C12124BFCB29E15 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -618,6 +619,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		079AFF1B1C12124BFCB29E15 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-NGRValidatorTests/Pods-NGRValidatorTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		7010E1BDA69E61E05205767B /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/NGRValidator/NGRValidator/Categories/NSError+NGRValidator.h
+++ b/NGRValidator/NGRValidator/Categories/NSError+NGRValidator.h
@@ -10,8 +10,10 @@
 
 extern NSString * const NGRValidatorDomain;
 
+extern NSString * const NGRValidatorPropertyNameKey;
+
 @interface NSError (NGRValidator)
 
-+ (instancetype)ngr_errorWithDescription:(NSString *)description;
++ (instancetype)ngr_errorWithDescription:(NSString *)description propertyName:(NSString *)propertyName;
 
 @end

--- a/NGRValidator/NGRValidator/Categories/NSError+NGRValidator.m
+++ b/NGRValidator/NGRValidator/Categories/NSError+NGRValidator.m
@@ -9,12 +9,21 @@
 #import "NSError+NGRValidator.h"
 
 NSString * const NGRValidatorDomain = @"com.ngr.validator.domain";
+NSString * const NGRValidatorPropertyNameKey = @"NGRValidatorPropertyNameKey";
+
 NSInteger const NGRValidationInconsistencyCode = 10000;
 
 @implementation NSError (NGRValidator)
 
-+ (instancetype)ngr_errorWithDescription:(NSString *)description {
-    return [NSError errorWithDomain:NGRValidatorDomain code:NGRValidationInconsistencyCode userInfo:@{NSLocalizedDescriptionKey : description}];
++ (instancetype)ngr_errorWithDescription:(NSString *)description propertyName:(NSString *)propertyName {
+    NSParameterAssert(description);
+    NSParameterAssert(propertyName);
+
+    return [NSError errorWithDomain:NGRValidatorDomain code:NGRValidationInconsistencyCode
+                           userInfo:@{
+                                   NSLocalizedDescriptionKey : description,
+                                   NGRValidatorPropertyNameKey : propertyName
+                           }];
 }
 
 @end

--- a/NGRValidator/NGRValidator/NGRPropertyValidator.h
+++ b/NGRValidator/NGRValidator/NGRPropertyValidator.h
@@ -80,7 +80,7 @@ extern NSUInteger const NGRPropertyValidatorDefaultPriority;
 @property (assign, readonly, nonatomic) NSUInteger priority;
 
 /**
- *  Array of NGRValidationRule objects, invoked one by one in validation proccess.
+ *  Array of NGRValidationRule objects, invoked one by one in validation process.
  */
 @property (strong, nonatomic, readonly) NSMutableArray *validationRules;
 
@@ -101,7 +101,7 @@ extern NSUInteger const NGRPropertyValidatorDefaultPriority;
  *  Validates property and gather all possible errors.
  *
  *  @param value The value of validated property.
- *  @return An NSArray of errrors if any, otherwise nil.
+ *  @return An NSArray of errors if any, otherwise nil.
  */
 - (NSArray *)complexValidationOfValue:(id)value;
 
@@ -110,7 +110,7 @@ extern NSUInteger const NGRPropertyValidatorDefaultPriority;
  *
  *  @param aClass           The class which given property should be. If nil, class validation will be skipped.
  *  @param name             The name of validator block.
- *  @param validationBlock  The validation block invoked during validation proccess.
+ *  @param validationBlock  The validation block invoked during validation process.
  */
 - (void)validateClass:(Class)aClass withName:(NSString *)name validationBlock:(NGRValidationBlock)block;
 

--- a/NGRValidator/NGRValidator/NGRPropertyValidator.m
+++ b/NGRValidator/NGRValidator/NGRPropertyValidator.m
@@ -156,14 +156,14 @@ NGRMsgKey *const NGRErrorUnexpectedClass = (NGRMsgKey *)@"NGRErrorUnexpectedClas
     
     NSString *customDescription = messages[self.property][key];
     if (customDescription) {
-        return [NSError ngr_errorWithDescription:customDescription];
+        return [NSError ngr_errorWithDescription:customDescription propertyName:self.property];
     }
     
     NSString *property = self.property ?: @"Validated property";
     NSString *propertyName = (self.localizedPropertyName) ?: [property ngr_stringByCapitalizeFirstLetter];
     NSString *space = propertyName.length > 0 ? @" " : @"";
     NSString *description = [NSString stringWithFormat:@"%@%@%@", propertyName, space, [self.messages messageForKey:key]];
-    return [NSError ngr_errorWithDescription:description];
+    return [NSError ngr_errorWithDescription:description propertyName:self.property];
 }
 
 - (BOOL)shouldValidate {

--- a/NGRValidator/NGRValidator/NGRValidationRule.h
+++ b/NGRValidator/NGRValidator/NGRValidationRule.h
@@ -14,7 +14,7 @@
 /**
  *  Designated initializer of NGRValidationRule.
  *
- *  @param name  Validation rule name stored for eaaier access and identification.
+ *  @param name  Validation rule name stored for easier access and identification.
  *  @param block Actual block with validation expression.
  *
  *  @return Instance of receiver.
@@ -22,7 +22,7 @@
 - (instancetype)initWithName:(NSString *)name block:(NGRValidationBlock)block NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Validation rule name storde for easier access and identification.
+ *  Validation rule name stored for easier access and identification.
  */
 @property (strong, readonly, nonatomic) NSString *name;
 

--- a/NGRValidator/NGRValidator/NGRValidator.h
+++ b/NGRValidator/NGRValidator/NGRValidator.h
@@ -26,7 +26,7 @@
  *  Validates model with given rules. Returns YES when validation succeeded, NO otherwise.
  *
  *  @param model    Model with properties to validate.
- *  @param error    Validation error with decription, nil when validation will pass.
+ *  @param error    Validation error with description, nil when validation will pass.
  *  @param delegate Allows delegate to customize entire error messages.
  *  @param rules    An array of validation rules. Every property in model is validated separately.
  *
@@ -38,7 +38,7 @@
  *  Validates model with given rules. Returns YES when validation succeeded, NO otherwise.
  *
  *  @param model    Model with properties to validate.
- *  @param error    Validation error with decription, nil when validation will pass.
+ *  @param error    Validation error with description, nil when validation will pass.
  *  @param scenario The scenario specifying which properties of model should be validated.
  *  @param delegate Allows delegate to customize entire error messages.
  *  @param rules    An array of validation rules. Every property in model is validated separately.

--- a/NGRValidatorTests/NGRPropertyValidator+SugarSyntaxSpec.m
+++ b/NGRValidatorTests/NGRPropertyValidator+SugarSyntaxSpec.m
@@ -6,7 +6,7 @@
 //
 //
 
-SpecBegin(NGRPropertyValidator_SugarSyntaxSpec)
+SpecBegin(NGRPropertyValidator_SugarSyntax)
 
 describe(@"Sugar syntax", ^{
     

--- a/NGRValidatorTests/NGRPropertyValidatorSpec.m
+++ b/NGRValidatorTests/NGRPropertyValidatorSpec.m
@@ -6,7 +6,7 @@
 //
 //
 
-SpecBegin(NGRPropertyValidatorSpec)
+SpecBegin(NGRPropertyValidator)
 
 describe(@"NGRPropertyValidator", ^{
     

--- a/NGRValidatorTests/NGRValidator+NSArraySpec.m
+++ b/NGRValidatorTests/NGRValidator+NSArraySpec.m
@@ -6,7 +6,7 @@
 //
 //
 
-SpecBegin(NGRValidator_NSArraySpec)
+SpecBegin(NGRValidator_NSArray)
 
 describe(@"Array validation", ^{
     

--- a/NGRValidatorTests/NGRValidator+NSDateSpec.m
+++ b/NGRValidatorTests/NGRValidator+NSDateSpec.m
@@ -6,7 +6,7 @@
 //
 //
 
-SpecBegin(NGRValidator_NSDateSpec)
+SpecBegin(NGRValidator_NSDate)
 
 describe(@"NSDate validation", ^{
     

--- a/NGRValidatorTests/NGRValidator+NSNumberSpec.m
+++ b/NGRValidatorTests/NGRValidator+NSNumberSpec.m
@@ -6,7 +6,7 @@
 //
 //
 
-SpecBegin(NGRValidator_NSNumberSpec)
+SpecBegin(NGRValidator_NSNumber)
 
 describe(@"NSNumber validation", ^{
 

--- a/NGRValidatorTests/NGRValidator+NSStringSpec.m
+++ b/NGRValidatorTests/NGRValidator+NSStringSpec.m
@@ -6,7 +6,7 @@
 //
 //
 
-SpecBegin(NGRValidator_NSStringSpec)
+SpecBegin(NGRValidator_NSString)
 
 describe(@"NSString validation", ^{
         

--- a/NGRValidatorTests/NGRValidator+ScenarioSpec.m
+++ b/NGRValidatorTests/NGRValidator+ScenarioSpec.m
@@ -9,7 +9,7 @@
 static NSString *const NGRFirstScenario = @"Fixture 1st Scenario";
 static NSString *const NGRSecondScenario = @"Fixture 2nd Scenario";
 
-SpecBegin(NGRValidator_ScenarioSpec)
+SpecBegin(NGRValidator_Scenario)
 
 describe(@"Scenario", ^{
     

--- a/NGRValidatorTests/NGRValidator+SyntaxSpec.m
+++ b/NGRValidatorTests/NGRValidator+SyntaxSpec.m
@@ -6,7 +6,7 @@
 //
 //
 
-SpecBegin(NGRValidator_SyntaxSpec)
+SpecBegin(NGRValidator_Syntax)
 
 describe(@"Syntax validation", ^{
 

--- a/NGRValidatorTests/NGRValidatorBehavior.m
+++ b/NGRValidatorTests/NGRValidatorBehavior.m
@@ -6,6 +6,8 @@
 //
 //
 
+#import "NSError+NGRValidator.h"
+
 SharedExamplesBegin(NGRValidatorBehavior)
 
 sharedExamplesFor(NGRMultiplePropertiesBehavior, ^(NSDictionary *data) {
@@ -110,6 +112,7 @@ sharedExamplesFor(NGRValueBehavior, ^(NSDictionary *data) {
             expect(success).to.beFalsy();
             expect(error).toNot.beNil();
             expect(error.localizedDescription).to.contain(msg);
+            expect(error.userInfo[NGRValidatorPropertyNameKey]).to.equal(@"value");
             
             // 2nd
             array = [NGRValidator validateModel:model delegate:nil rules:rules];
@@ -199,6 +202,7 @@ sharedExamplesFor(NGRScenarioFailureBehavior, ^(NSDictionary *data) {
             expect(success).to.beFalsy();
             expect(error).toNot.beNil();
             expect(error.localizedDescription).to.contain(msg);
+            expect(error.userInfo[NGRValidatorPropertyNameKey]).to.equal(@"value");
             
             // 2nd
             array = [NGRValidator validateModel:model scenario:scenario delegate:nil rules:rules];

--- a/NGRValidatorTests/NGRValidatorSpec.m
+++ b/NGRValidatorTests/NGRValidatorSpec.m
@@ -6,9 +6,9 @@
 //
 //
 
-SpecBegin(NGRValidatorSpec)
+SpecBegin(NGRValidator)
 
-describe(@"NGRValidatorSpec", ^{
+describe(@"NGRValidator", ^{
     
     /** Multiple errors test: **/
     

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Expecta (0.4.0)
-  - Specta (0.5.0)
+  - Expecta (1.0.5)
+  - Specta (1.0.5)
 
 DEPENDENCIES:
   - Expecta
   - Specta
 
 SPEC CHECKSUMS:
-  Expecta: 392a6b5bfb9f4097e47dd8064d9b732079490332
-  Specta: eb90708ed77569bbda089f8ead10bb99b8e9489e
+  Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
+  Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
-COCOAPODS: 0.36.3
+COCOAPODS: 0.39.0


### PR DESCRIPTION
This PR changes following things:
- Bumped Specta to 1.0.5
- Bumped Expecta to 1.0.5
- Modernised Specta tests to make sure output naming is correct (no more `*SpecSpec` in output)
- Fixed a few minor typos here and there

Last but not least I've added a way to determine which property did not validate by introducing `NGRValidatorPropertyNameKey` key to returned `NSError` user info. This might be useful in scenarios where you receive multiple errors and you want to inform user in UI which input values are incorrect. 
